### PR TITLE
Update link to example in README

### DIFF
--- a/concert_service_gazebo/README.md
+++ b/concert_service_gazebo/README.md
@@ -70,7 +70,7 @@ world_file: concert_service_gazebo/empty_world.world
 
 # An example
 
-Take a look at the [gazebo_solution](https://github.com/robotics-in-concert/rocon_demos/tree/gazebo_concert/gazebo_solution) demo.
+Take a look at the [concert_tutorials/gazebo_concert](https://github.com/robotics-in-concert/rocon_tutorials/tree/indigo/concert_tutorials/gazebo_concert) demo in the [rocon_tutorials repository](https://github.com/robotics-in-concert/rocon_tutorials).
 
 * Install Rocon:
 


### PR DESCRIPTION
At 6497f837e14672ebc05319534e1c4f8cbeb1860e of the rocon_demos repository
(https://github.com/robotics-in-concert/rocon_demos), gazebo_solution was
migrated to the rocon_tutorials repository
(https://github.com/robotics-in-concert/rocon_tutorials) and renamed to
"gazebo_concert". Compare with commit c92d9e40938f0b3e75979a7cba7dc52ceaf572c1
of rocon_tutorials.
